### PR TITLE
Move Dockerfiles from ITKDevelopmentEnvironment to this project

### DIFF
--- a/BuildRobot/gcc-5.1/Dockerfile
+++ b/BuildRobot/gcc-5.1/Dockerfile
@@ -1,0 +1,51 @@
+FROM gcc:5.1
+MAINTAINER Francois Budin <francois.budin@kitware.com>
+
+# Install required packages and clean in one step to minimize
+# image size.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates \
+    curl \
+    wget \
+    git \
+    openssh-client \
+    subversion \
+    autoconf \
+    build-essential \
+    imagemagick \
+    libbz2-dev \
+    libcurl4-openssl-dev \
+    libevent-dev \
+    libffi-dev \
+    libglib2.0-dev \
+    libjpeg-dev \
+    liblzma-dev \
+    libmagickcore-dev \
+    libmagickwand-dev \
+    libmysqlclient-dev \
+    libncurses-dev \
+    libpq-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    libxml2-dev \
+    libxslt-dev \
+    libyaml-dev \
+    zlib1g-dev \
+    python && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
+RUN curl $GET_PIP_URL > /tmp/get-pip.py
+RUN python /tmp/get-pip.py && python -m pip install cmake
+
+# Normal user
+RUN useradd -m kitware
+RUN echo 'root:kitware' | chpasswd
+RUN echo 'kitware:kitware' | chpasswd
+ENV HOME /home/kitware
+USER kitware
+WORKDIR /home/kitware
+
+CMD ["/bin/bash"]
+

--- a/BuildRobot/module-ci/Dockerfile
+++ b/BuildRobot/module-ci/Dockerfile
@@ -1,0 +1,41 @@
+FROM docker:18.01.0-ce-git
+MAINTAINER Matt McCormick <matt.mccormick@kitware.com>
+
+RUN echo 'http://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories \
+  && apk update \
+  && apk add \
+    curl \
+    curl-dev \
+    cmake \
+    expat-dev \
+    g++ \
+    make \
+    jpeg-dev \
+    libpng-dev \
+    ninja \
+    python3-dev \
+    tiff-dev \
+    zlib-dev \
+  && ln -s /usr/bin/python3 /usr/bin/python
+
+# ITK master 2017-12-21
+ENV ITK_VERSION v4.13.0
+RUN git clone https://github.com/InsightSoftwareConsortium/ITK.git \
+  && cd ITK \
+  && git checkout ${ITK_VERSION} \
+  && rm -rf .git
+RUN mkdir ITK-build \
+  && cd ITK-build \
+  && cmake \
+    -G Ninja \
+    -DCMAKE_BUILD_TYPE:STRING=MinSizeRel \
+    -DBUILD_TESTING:BOOL=OFF \
+    -DBUILD_SHARED_LIBS:BOOL=ON \
+    -DITK_USE_SYSTEM_EXPAT:BOOL=ON \
+    -DITK_USE_SYSTEM_JPEG:BOOL=ON \
+    -DITK_USE_SYSTEM_PNG:BOOL=ON \
+    -DITK_USE_SYSTEM_TIFF:BOOL=ON \
+    -DITK_USE_SYSTEM_ZLIB:BOOL=ON \
+    ../ITK \
+  && ninja \
+  && find . -name '*.o' -delete

--- a/BuildRobot/module-ci/README.md
+++ b/BuildRobot/module-ci/README.md
@@ -1,0 +1,10 @@
+This Docker image provides the build environment for testing [ITK
+modules](https://itk.org/ITKSoftwareGuide/html/Book1/ITKSoftwareGuide-Book1ch9.html#x48-1460009)
+on GitHub with the [CircleCI](https://circleci.com) or other continuous
+integration (CI) service.
+
+This includes:
+
+1. Build tools like CMake, Ninja, GCC
+2. An ITK build at /ITK-build
+3. Tools like Docker, zstd to build Python packages


### PR DESCRIPTION
These docker images are designed to test ITK. This patch provides two new
docker images:
* gcc-5.1
* module-ci